### PR TITLE
Simplify packet length read/write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target
 *.rs.bk
 .pcap
 .env
+.idea

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,23 +59,8 @@ The first 8 bytes of a viper response and request have the following format:
 00 06 L1 L2 C1 C2 00 00
 ```
 
-- The L1 and L2 bytes indicate the length of the bytes to read.
+- The L1 and L2 bytes indicate the length of the bytes to read in LITTLE ENDIAN encoding.
 - The C1 and C2 bytes are channel (or control bytes). These are `00 00` in case of some requests.
-
-## Determining the length of the buffer
-
-To accurately read the length of a response, this is determined by doing the following:
-
-```
-(L1 to decimal) + ((L2 to decimal) * 255) + L2 to decimal
-```
-
-To set the length of a request do:
-
-```
-length of request / 255 = L2
-(length of request % 255) - L2 = L1
-```
 
 ## Opening a channel
 A channel is opened by executing the following bytes:
@@ -90,20 +75,20 @@ In this particular example I'm opening a `UAUT` (55 41 55 54) channel with the c
 
 Other channels that can be opened:
 
-Channel | Interpretation
----------|-------------------------------------------
-CSPB     | ?
-CTPP     | Used to link actuators / open doors / ???
-ECHO     | ?
-ECHO_SRV | ?
-FRCG     | Grabs face recognition details
-INFO     | Fetches information from the device
-PUSH     | To set a push token
-RTPC     | ? Something related to camera ?
-UAUT     | Used for authorizing with the device
-UADM     | Administrator channel
-UCFG     | Used to extract configuration details
-UDPM     | ? Precursor for UDP calls ?
+| Channel  | Interpretation                            |
+|----------|-------------------------------------------|
+ | CSPB     | ?                                         |
+ | CTPP     | Used to link actuators / open doors / ??? |
+ | ECHO     | ?                                         |
+ | ECHO_SRV | ?                                         |
+ | FRCG     | Grabs face recognition details            |
+ | INFO     | Fetches information from the device       |
+ | PUSH     | To set a push token                       |
+ | RTPC     | ? Something related to camera ?           |
+ | UAUT     | Used for authorizing with the device      |
+ | UADM     | Administrator channel                     |
+ | UCFG     | Used to extract configuration details     |
+ | UDPM     | ? Precursor for UDP calls ?               |
 
 In some cases extra data can be passed to opening a channel, which is done like such:
 
@@ -180,13 +165,13 @@ S3 S4 S5 S6 S7 S8 00 00 <-- ..
 - S1 till S8 = Another actuator ID
 - [[ BODY ]] = A dynamic set of bytes
 
-A1 A2 | Interpretation: | Response | Request
-------|-----------------|----------|--------
-00 18 | ?               | ✅       | ✅
-20 18 | ?               |          | ✅
-40 18 | ?               | ✅       | ✅
-60 18 | ?               | ✅       | ✅
-c0 18 | ?               |          | ✅
+| A1 A2 | Interpretation: | Response | Request |
+|-------|-----------------|----------|---------|
+ | 00 18 | ?               | ✅        | ✅       |
+ | 20 18 | ?               |          | ✅       |
+ | 40 18 | ?               | ✅        | ✅       |
+ | 60 18 | ?               | ✅        | ✅       |
+ | c0 18 | ?               |          | ✅       |
 
 ---
 

--- a/src/viper_client/command.rs
+++ b/src/viper_client/command.rs
@@ -1,3 +1,4 @@
+use actix_web::web::to;
 use serde::{Deserialize, Serialize};
 
 const OPEN:  [u8; 8] = [0xcd, 0xab, 0x01, 0x00, 0x07, 0x00, 0x00, 0x00];
@@ -92,10 +93,7 @@ impl Command {
     }
 
     pub fn buffer_length(b2: u8, b3: u8) -> usize {
-        let b2 = b2 as usize;
-        let b3 = b3 as usize;
-
-        (b3 * 255) + b2 + b3
+        u16::from_le_bytes([b2, b3]) as usize
     }
 
     pub fn channel(command: &String,
@@ -145,16 +143,9 @@ impl Command {
     }
 
     fn header(total: &[u8]) -> [u8; 8] {
-        let (length, second) = Command::byte_lengths(&total);
+        let len = total.len().to_le_bytes();
 
-        [0x00, 0x06, length, second, 0x00, 0x00, 0x00, 0x00]
-    }
-
-    fn byte_lengths(bytes: &[u8]) -> (u8, u8) {
-        let second = bytes.len() / 255;
-        let length = (bytes.len() % 255) - second;
-
-        (length as u8, second as u8)
+        [0x00, 0x06, len[0], len[1], 0x00, 0x00, 0x00, 0x00]
     }
 }
 


### PR DESCRIPTION
Simplify the way the length of a packet is read/written. Just use Little Endian encoding.